### PR TITLE
Added documentation for setting the base_url in kazoo.Client()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,14 @@ Or using an api key::
     >>>client = kazoo.Client(api_key="sdfasdfas")
     >>>client.authenticate()
 
+The default api url is: 'http://api.2600hz.com:8000/v1'.  You can override this
+by supplying an extra argument, 'base_url' to kazoo.Client().
+
+Example of overriding 'base_url'::
+
+    >>>client = kazoo.Client(base_url='http://api.example.com:8000/v1',
+                             api_key="sdfasdfas")
+
 API calls which require data take it in the form of a required argument
 called 'data' which is the last argument to the method. For example ::
 

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -163,6 +163,14 @@ class Client(object):
         >>>client = kazoo.Client(username="myusername", password="mypassword", account_name="my_account_name")
         >>>client.authenticate()
 
+    The default api url is: 'http://api.2600hz.com:8000/v1'.  You can override this
+    by supplying an extra argument, 'base_url' to kazoo.Client().
+
+    Example of overriding 'base_url'::
+
+        >>>client = kazoo.Client(base_url='http://api.example.com:8000/v1',
+                                 api_key="sdfasdfas")
+
     API calls which require data take it in the form of a required argument
     called 'data' which is the last argument to the method. For example ::
 


### PR DESCRIPTION
I noticed there was no way documentation on how to provide a different `base_url` fo kazoo.Client() than the default, which is: http://api.example.com:8000/v1.  

I looked around in client.py and have updated the documentation so that others will know how to do this in the future without reading the source.